### PR TITLE
Fix for disappearing files

### DIFF
--- a/core/components/ajaxupload/model/ajaxupload/ajaxupload.class.php
+++ b/core/components/ajaxupload/model/ajaxupload/ajaxupload.class.php
@@ -84,7 +84,7 @@ class AjaxUpload
             'uid' => $this->getOption('uid', $config, md5($this->modx->getOption('site_url') . '-' . $resourceId)),
             'uploadAction' => $assetsUrl . 'connector.php',
             'newFilePermissions' => '0664',
-            'maxConnections' => 3,
+            'maxConnections' => 1,
             'cacheExpires' => intval($this->getOption('cacheExpires', $config, 4)),
             'allowOverwrite' => (bool)$this->getOption('allowOverwrite', $config, false),
             'language' => $this->modx->getOption('language', $config, $this->modx->cultureKey, true)


### PR DESCRIPTION
If you have a good Internet connection, uploading multiple files at the same time leads to the loss of some. That is expressed in the non-saving of data in the session variable when competing requests. Strange bug, but this is only way to fix. Also this is fix for issue https://github.com/Jako/AjaxUpload/issues/18