### PR TITLE
Wrong content in snippet AjaxUploadRequired

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -152,7 +152,7 @@
         {
           "name": "AjaxUploadRequired",
           "description": "AjaxUpload Formit hook. Add an error message, when no file is uploaded.",
-          "file": "ajaxuploadattachments.hook.php",
+          "file": "ajaxuploadrequired.hook.php",
           "properties": [
             {
               "name": "ajaxuploadRequiredMessage",


### PR DESCRIPTION
On installation, the snippet AjaxUploadRequired seems to read the content from the wrong file.

https://community.modx.com/t/ajaxuploadrequired-does-not-seem-to-work/6311