### PR TITLE
Add option to sanitize file names

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -201,6 +201,16 @@
         "key": "image_tpl",
         "area": "site",
         "value": "tplAjaxUploadImage"
+      },
+      {
+        "key": "filename_restrict_chars",
+        "area": "file",
+        "value": "pattern"
+      },
+      {
+        "key": "filename_restrict_chars_pattern",
+        "area": "file",
+        "value": "/[\\0\\x0B\\t\\n\\r\\f\\a,.?!;:()&=+%#<>\"~`@\\?\\[\\]\\{\\}\\|\\^\\'\\\\\\\\]/"
       }
     ]
   },

--- a/_build/config.json
+++ b/_build/config.json
@@ -203,6 +203,11 @@
         "value": "tplAjaxUploadImage"
       },
       {
+        "key": "filename_translit",
+        "area": "file",
+        "value": "iconv_ascii"
+      },
+      {
         "key": "filename_restrict_chars",
         "area": "file",
         "value": "pattern"

--- a/_build/config.json
+++ b/_build/config.json
@@ -120,6 +120,11 @@
               "name": "ajaxuploadAllowOverwrite",
               "type": "combo-boolean",
               "value": "1"
+            },
+            {
+              "name": "ajaxuploadSanitizeFilename",
+              "type": "combo-boolean",
+              "value": "0"
             }
           ]
         },

--- a/core/components/ajaxupload/lexicon/en/setting.inc.php
+++ b/core/components/ajaxupload/lexicon/en/setting.inc.php
@@ -11,3 +11,7 @@ $_lang['setting_ajaxupload.debug'] = 'Debug';
 $_lang['setting_ajaxupload.debug_desc'] = 'Log debug information in the MODX error log.';
 $_lang['setting_ajaxupload.image_tpl'] = 'Image Template';
 $_lang['setting_ajaxupload.image_tpl_desc'] = 'Name of a chunk that contains the HTML code for displaying the uploaded image.';
+$_lang['setting_ajaxupload.filename_restrict_chars'] = 'Filename character restriction method';
+$_lang['setting_ajaxupload.filename_restrict_chars_desc'] = 'Identical twin of the system setting under FURLs, for formatting Resource alias. "pattern" allows a RegEx pattern to be provided, "legal" allows any legal URL characters, "alpha" allows only letters of the alphabet, and "alphanumeric" allows only letters and numbers.';
+$_lang['setting_ajaxupload.filename_restrict_chars_pattern'] = 'Filename character restriction pattern';
+$_lang['setting_ajaxupload.filename_restrict_chars_pattern_desc'] = 'A valid RegEx for restricting characters in the filename. Restriction method must be set to "pattern".';

--- a/core/components/ajaxupload/lexicon/en/setting.inc.php
+++ b/core/components/ajaxupload/lexicon/en/setting.inc.php
@@ -11,6 +11,9 @@ $_lang['setting_ajaxupload.debug'] = 'Debug';
 $_lang['setting_ajaxupload.debug_desc'] = 'Log debug information in the MODX error log.';
 $_lang['setting_ajaxupload.image_tpl'] = 'Image Template';
 $_lang['setting_ajaxupload.image_tpl_desc'] = 'Name of a chunk that contains the HTML code for displaying the uploaded image.';
+
+$_lang['setting_ajaxupload.filename_translit'] = 'Filename transliteration method';
+$_lang['setting_ajaxupload.filename_translit_desc'] = 'Defaults to iconv_ascii, to eliminate potential issues with accented characters. If empty, the value from the equivalent FURLs setting is inherited.';
 $_lang['setting_ajaxupload.filename_restrict_chars'] = 'Filename character restriction method';
 $_lang['setting_ajaxupload.filename_restrict_chars_desc'] = 'Identical twin of the system setting under FURLs, for formatting Resource alias. "pattern" allows a RegEx pattern to be provided, "legal" allows any legal URL characters, "alpha" allows only letters of the alphabet, and "alphanumeric" allows only letters and numbers.';
 $_lang['setting_ajaxupload.filename_restrict_chars_pattern'] = 'Filename character restriction pattern';

--- a/core/components/ajaxupload/src/AjaxUpload.php
+++ b/core/components/ajaxupload/src/AjaxUpload.php
@@ -431,9 +431,11 @@ class AjaxUpload
                 if ($sanitizeFilename) {
                     $pathinfo = pathinfo($fileInfo['originalName']);
 
-                    // Replace all spaces and punctuation characters with -
-                    $fileName = str_replace(['/',"'",'"','(',')',';','>','<',',','.','?','!'], '-', $pathinfo['filename']);
-                    $fileName = $this->modx->filterPathSegment($fileName);
+                    // Filter spaces and punctuation characters
+                    $fileName = $this->modx->filterPathSegment($pathinfo['filename'], [
+                        'friendly_alias_restrict_chars' => $this->modx->getOption('ajaxupload.filename_restrict_chars', null, $this->modx->getOption('friendly_alias_restrict_chars')),
+                        'friendly_alias_restrict_chars_pattern' => $this->modx->getOption('ajaxupload.filename_restrict_chars_pattern', null, $this->modx->getOption('friendly_alias_restrict_chars_pattern')),
+                    ]);
 
                     // Reunite with file extension
                     $fileInfo['originalName'] = $fileName . '.' . $pathinfo['extension'];

--- a/core/components/ajaxupload/src/AjaxUpload.php
+++ b/core/components/ajaxupload/src/AjaxUpload.php
@@ -434,9 +434,6 @@ class AjaxUpload
                     // Replace all spaces and special characters with -
                     $fileName = $this->modx->filterPathSegment($pathinfo['filename']);
                     $fileName = preg_replace('/[^A-Za-z0-9 _-]/', '', $fileName); // strip non-alphanumeric characters
-                    $fileName = str_replace(',', '-', $fileName); // replace comma
-                    $fileName = str_replace('.', '-', $fileName); // replace period
-                    $fileName = trim($fileName, '-'); // trim edges
 
                     // Reunite with file extension
                     $fileInfo['originalName'] = $fileName . '.' . $pathinfo['extension'];

--- a/core/components/ajaxupload/src/AjaxUpload.php
+++ b/core/components/ajaxupload/src/AjaxUpload.php
@@ -431,9 +431,9 @@ class AjaxUpload
                 if ($sanitizeFilename) {
                     $pathinfo = pathinfo($fileInfo['originalName']);
 
-                    // Replace all spaces and special characters with -
-                    $fileName = $this->modx->filterPathSegment($pathinfo['filename']);
-                    $fileName = preg_replace('/[^A-Za-z0-9 _-]/', '', $fileName); // strip non-alphanumeric characters
+                    // Replace all spaces and punctuation characters with -
+                    $fileName = str_replace(['/',"'",'"','(',')',';','>','<',',','.','?','!'], '-', $pathinfo['filename']);
+                    $fileName = $this->modx->filterPathSegment($fileName);
 
                     // Reunite with file extension
                     $fileInfo['originalName'] = $fileName . '.' . $pathinfo['extension'];

--- a/core/components/ajaxupload/src/AjaxUpload.php
+++ b/core/components/ajaxupload/src/AjaxUpload.php
@@ -430,14 +430,10 @@ class AjaxUpload
             if (file_exists($fileInfo['path'] . $fileInfo['uniqueName'])) {
                 if ($sanitizeFilename) {
                     $pathinfo = pathinfo($fileInfo['originalName']);
-                    $fileName = $pathinfo['filename'];
 
                     // Replace all spaces and special characters with -
-                    $fileName = strip_tags($fileName); // strip HTML
-                    $fileName = strtolower($fileName); // convert to lowercase
+                    $fileName = $this->modx->filterPathSegment($pathinfo['filename']);
                     $fileName = preg_replace('/[^A-Za-z0-9 _-]/', '', $fileName); // strip non-alphanumeric characters
-                    $fileName = preg_replace('/\s+/', '-', $fileName); // convert white-space to dash
-                    $fileName = preg_replace('/-+/', '-', $fileName); // convert multiple dashes to one
                     $fileName = str_replace(',', '-', $fileName); // replace comma
                     $fileName = str_replace('.', '-', $fileName); // replace period
                     $fileName = trim($fileName, '-'); // trim edges

--- a/core/components/ajaxupload/src/AjaxUpload.php
+++ b/core/components/ajaxupload/src/AjaxUpload.php
@@ -433,6 +433,7 @@ class AjaxUpload
 
                     // Filter spaces and punctuation characters
                     $fileName = $this->modx->filterPathSegment($pathinfo['filename'], [
+                        'friendly_alias_translit' => $this->modx->getOption('ajaxupload.filename_translit', null, $this->modx->getOption('friendly_alias_translit')),
                         'friendly_alias_restrict_chars' => $this->modx->getOption('ajaxupload.filename_restrict_chars', null, $this->modx->getOption('friendly_alias_restrict_chars')),
                         'friendly_alias_restrict_chars_pattern' => $this->modx->getOption('ajaxupload.filename_restrict_chars_pattern', null, $this->modx->getOption('friendly_alias_restrict_chars_pattern')),
                     ]);

--- a/core/components/ajaxupload/src/Snippets/AjaxUpload2FormitHook.php
+++ b/core/components/ajaxupload/src/Snippets/AjaxUpload2FormitHook.php
@@ -28,6 +28,7 @@ class AjaxUpload2FormitHook extends Hook
             'cacheExpires::int' => $this->modx->getOption('ajaxupload.cache_expires', null, '4'),
             'clearQueue::bool' => false,
             'allowOverwrite::bool' => true,
+            'sanitizeFilename::bool' => false,
         ];
     }
 
@@ -54,7 +55,12 @@ class AjaxUpload2FormitHook extends Hook
             return false;
         }
 
-        $error = $this->ajaxupload->saveUploads($this->getProperty('target'), $this->getProperty('clearQueue'), $this->getProperty('allowOverwrite'));
+        $error = $this->ajaxupload->saveUploads(
+            $this->getProperty('target'),
+            $this->getProperty('clearQueue'),
+            $this->getProperty('allowOverwrite'),
+            $this->getProperty('sanitizeFilename')
+        );
         if ($error) {
             $this->hook->addError($this->getProperty('uid'), $error);
             return false;


### PR DESCRIPTION
When enabled, all spaces and special characters are replaced with a dash.

This scratches my own itch in issues #69 and #70.

I don't know if the functionality is already complete like this, and I haven't tested it extensively, so please consider this as work in progress. But is it something you'd like to implement?