### PR TITLE
Rename AjaxUploadRemoveHook snippet

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -163,7 +163,7 @@
           "file": "ajaxuploadattachments.hook.php"
         },
         {
-          "name": "AjaxUploadRemoveHook",
+          "name": "AjaxUploadRemove",
           "description": "AjaxUpload Formit hook. Remove the uploaded files after sending the mail.",
           "file": "ajaxuploadremove.hook.php"
         },


### PR DESCRIPTION
It's being referred to as AjaxUploadRemove in docs and comments, so I assume that's the intended name.